### PR TITLE
fix(26): Update ClockUtilTest

### DIFF
--- a/persistence/src/test/java/org/wcdevs/blog/core/persistence/util/ClockUtilTest.java
+++ b/persistence/src/test/java/org/wcdevs/blog/core/persistence/util/ClockUtilTest.java
@@ -1,15 +1,16 @@
 package org.wcdevs.blog.core.persistence.util;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 class ClockUtilTest {
   @Test
   void utcNow() {
     // some nanoseconds will pass between computation of the first and second time
-    assertEquals(LocalDateTime.now(ZoneId.of("UTC")).withNano(0), ClockUtil.utcNow().withNano(0));
+    assertEquals(LocalDateTime.now(ZoneId.of("UTC")).withNano(0).withSecond(0),
+                 ClockUtil.utcNow().withNano(0).withSecond(0));
   }
 }


### PR DESCRIPTION
- Make both (test time and utility time) to use `0` seconds

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other non-breaking change (enhancement, tests, documentation, chore and the like)

## And
- [x] This Pull Request DOES NOT target the `main` (production) branch on this repository (if so it
must point to a feature branch or to the `develop` (staging) branch).
- [x] I have read the [**CONTRIBUTING**](https://github.com/lealceldeiro/org.wcdevs.blog.core/blob/main/CONTRIBUTING.md)
document.
- [ ] I have added/updated tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] There are no other open [Pull Requests](https://github.com/lealceldeiro/org.wcdevs.blog.core/pulls)
for the same update/change.

### Fixes

  - closes #30 
